### PR TITLE
Fix react-scripts version to avoid an error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^12.1.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3",
+    "react-scripts": "5.0.1",
     "web-vitals": "^1.0.1"
   },
   "scripts": {


### PR DESCRIPTION
The fix for the error that will be produced in user setup: 

```
node -v
v18.20.1
```

Error that will be produced form `react-scripts` library: 

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/tokenize' is not defined by "exports" in /tmp/workspace/node_modules/postcss-safe-parser/node_modules/postcss/package.json
```

The error is fixed by upgrading https://www.npmjs.com/package/react-scripts to `5.0.1` version.